### PR TITLE
feat: sum counts with matching substring

### DIFF
--- a/db.py
+++ b/db.py
@@ -38,6 +38,16 @@ class DbAccess:
         else:
             return data[0]
 
+    def get_sum(self, connection, url):
+        """ Get the sum of counts of urls that contain the given substring """
+        cursor = connection.cursor()
+        cursor.execute('SELECT SUM(count) FROM url WHERE instr(url, ?)>0', (url,))
+        data = cursor.fetchone()
+        if data is None:
+            return 0
+        else:
+            return data[0]
+
     def add_view(self, connection, url):
         """ Create url entry if needed and increase url count and add cookie value to views if value is not stored """
         cursor = connection.cursor()

--- a/db.py
+++ b/db.py
@@ -43,10 +43,10 @@ class DbAccess:
         cursor = connection.cursor()
         cursor.execute('SELECT SUM(count) FROM url WHERE instr(url, ?)>0', (url,))
         data = cursor.fetchone()
+        data = data[0]
         if data is None:
             return 0
-        else:
-            return data[0]
+        return data
 
     def add_view(self, connection, url):
         """ Create url entry if needed and increase url count and add cookie value to views if value is not stored """

--- a/server.py
+++ b/server.py
@@ -102,6 +102,21 @@ def no_count_tag_route(url):
 
     return make_svg_response(count, url, False)
 
+@app.route("/sum", endpoint="sum_raw_route")
+@utils.get_and_validate_url
+def sum_raw_route(url):
+    """ Return the count for a url """
+    connection = db_connection.get_connection()
+    count = db_connection.get_sum(connection, url)
+    return make_text_response(count, url, False)
+
+@app.route("/sum/tag.svg", endpoint="sum_tag_route")
+@utils.get_and_validate_url
+def sum_tag_route(url):
+    """ Return the count for a url """
+    connection = db_connection.get_connection()
+    count = db_connection.get_sum(connection, url)
+    return make_svg_response(count, url, False)
 
 @app.after_request
 def add_header(r):


### PR DESCRIPTION
Allows user to get sum of counts of urls that contain the given substring. Useful for getting total count for domain / subdomain / subdirectory, etc.